### PR TITLE
Allow for parallel installs of blktap2.5

### DIFF
--- a/lib/tapctl.ml
+++ b/lib/tapctl.ml
@@ -301,7 +301,7 @@ let canonicalise x =
 				if Sys.file_exists possibility
 				then Some possibility
 				else None
-		) None (paths @ xen_paths) in
+		) None (xen_paths @ paths) in
 		match first_hit with
 		| None -> x
 		| Some hit -> hit


### PR DESCRIPTION
In xenserver-core we may end up with parallel installs of blktap2.5. To make this work we need to use environment variables to find the right tap-ctl and tapdisk commands.
